### PR TITLE
fix: Add "entry-asar/*" to the files section of package.json (fixes #3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "dist/*",
+    "entry-asar/*",
     "README.md"
   ],
   "author": "Samuel Attard",


### PR DESCRIPTION
Fixes bug #3 where the whole process failed because it could not find the index.js file in the entry-asar directory. Adding this entry will make sure the files in the entry-asar directory are available when this package is installed using npm.