### PR TITLE
fix: use setEncoding() and read() for crypto.createHash instead of digest()

### DIFF
--- a/src/sha.ts
+++ b/src/sha.ts
@@ -5,11 +5,12 @@ import { d } from './debug';
 export const sha = async (filePath: string) => {
   d('hashing', filePath);
   const hash = crypto.createHash('sha256');
+  hash.setEncoding('hex');
   const fileStream = fs.createReadStream(filePath);
   fileStream.pipe(hash);
   await new Promise((resolve, reject) => {
     fileStream.on('end', () => resolve());
     fileStream.on('error', (err) => reject(err));
   });
-  return hash.digest('hex');
+  return hash.read();
 };


### PR DESCRIPTION
The digest() function seems unreliable when used together with streams, causing it to sometimes give back no hash.