### PR TITLE
Handle `file` errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
     "lint": "prettier --check \"src/**/*.ts\"",
-    "prepublishOnly": "npm run build",
+    "prepack": "npm run build",
     "test": "exit 0"
   },
   "devDependencies": {

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -34,7 +34,7 @@ export const getAllAppFiles = async (appPath: string): Promise<AppFile[]> => {
     if (info.isFile()) {
       let fileType = AppFileType.PLAIN;
 
-      const fileOutput = await spawn('file', ['--brief', '--no-pad', p]);
+      const fileOutput = await spawn('file', ['--brief', '--no-pad', p]).catch(() => '');
       if (p.includes('app.asar')) {
         fileType = AppFileType.APP_CODE;
       } else if (fileOutput.startsWith(MACHO_PREFIX)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     ],
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
-    "declaration": true
+    "declaration": true,
+    "newLine": "lf"
   },
   "include": [
     "src"


### PR DESCRIPTION
The `file` command may sometimes fail. For example, certain versions of it fail on `.wasm` files: https://bugs.astron.com/view.php?id=170

It's only used for determining if a file is a Mach-O file, so it seems like errors can be safely ignored here.

This PR makes it possible to package an app that contains a wasm file with asar disabled.