### PR TITLE
feat: merge ASARs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "apple silicon",
     "universal"
   ],
-  "repository": {	
+  "repository": {
     "type": "git",
     "url": "https://github.com/electron/universal.git"
   },
@@ -33,6 +33,7 @@
     "@continuous-auth/semantic-release-npm": "^2.0.0",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.4",
+    "@types/minimatch": "^3.0.5",
     "@types/node": "^14.14.7",
     "@types/plist": "^3.0.2",
     "husky": "^4.3.0",
@@ -47,6 +48,7 @@
     "debug": "^4.3.1",
     "dir-compare": "^2.4.0",
     "fs-extra": "^9.0.1",
+    "minimatch": "^3.0.4",
     "plist": "^3.0.4"
   },
   "husky": {

--- a/src/asar-utils.ts
+++ b/src/asar-utils.ts
@@ -19,7 +19,7 @@ export type MergeASARsOptions = {
   arm64AsarPath: string;
   outputAsarPath: string;
 
-  uniqueAllowList?: string;
+  singleArchFiles?: string;
 };
 
 // See: https://github.com/apple-opensource-mirror/llvmCore/blob/0c60489d96c87140db9a6a14c6e82b15f5e5d252/include/llvm/Object/MachOFormat.h#L108-L112
@@ -68,7 +68,7 @@ function isDirectory(a: string, file: string): boolean {
   return Boolean('files' in asar.statFile(a, file));
 }
 
-function checkUnique(archive: string, file: string, allowList?: string): void {
+function checkSingleArch(archive: string, file: string, allowList?: string): void {
   if (allowList === undefined || !minimatch(file, allowList, { matchBase: true })) {
     throw new Error(
       `Detected unique file "${file}" in "${archive}" not covered by ` +
@@ -81,7 +81,7 @@ export const mergeASARs = async ({
   x64AsarPath,
   arm64AsarPath,
   outputAsarPath,
-  uniqueAllowList,
+  singleArchFiles,
 }: MergeASARsOptions): Promise<void> => {
   d(`merging ${x64AsarPath} and ${arm64AsarPath}`);
 
@@ -118,13 +118,13 @@ export const mergeASARs = async ({
 
   for (const file of x64Files) {
     if (!arm64Files.has(file)) {
-      checkUnique(x64AsarPath, file, uniqueAllowList);
+      checkSingleArch(x64AsarPath, file, singleArchFiles);
     }
   }
   const arm64Unique = [];
   for (const file of arm64Files) {
     if (!x64Files.has(file)) {
-      checkUnique(arm64AsarPath, file, uniqueAllowList);
+      checkSingleArch(arm64AsarPath, file, singleArchFiles);
       arm64Unique.push(file);
     }
   }

--- a/src/asar-utils.ts
+++ b/src/asar-utils.ts
@@ -31,10 +31,6 @@ const MACHO_MAGIC = new Set([
   // 64-bit Mach-O
   0xfeedfacf,
   0xcffaedfe,
-
-  // Universal
-  0xcafebabe,
-  0xbebafeca,
 ]);
 
 export const detectAsarMode = async (appPath: string) => {

--- a/src/asar-utils.ts
+++ b/src/asar-utils.ts
@@ -1,13 +1,40 @@
 import * as asar from 'asar';
+import { execFileSync } from 'child_process';
 import * as crypto from 'crypto';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as minimatch from 'minimatch';
+import * as os from 'os';
 import { d } from './debug';
 
 export enum AsarMode {
   NO_ASAR,
   HAS_ASAR,
 }
+
+export type FuseASARsOptions = {
+  x64: string;
+  arm64: string;
+  output: string;
+
+  lipo?: string;
+  uniqueAllowList?: string;
+};
+
+// See: https://github.com/apple-opensource-mirror/llvmCore/blob/0c60489d96c87140db9a6a14c6e82b15f5e5d252/include/llvm/Object/MachOFormat.h#L108-L112
+const MACHO_MAGIC = new Set([
+  // 32-bit Mach-O
+  0xfeedface,
+  0xcefaedfe,
+
+  // 64-bit Mach-O
+  0xfeedfacf,
+  0xcffaedfe,
+
+  // Universal
+  0xcafebabe,
+  0xbebafeca,
+]);
 
 export const detectAsarMode = async (appPath: string) => {
   d('checking asar mode of', appPath);
@@ -30,4 +57,154 @@ export const generateAsarIntegrity = (asarPath: string) => {
       .update(asar.getRawHeader(asarPath).headerString)
       .digest('hex'),
   };
+};
+
+function toRelativePath(file: string): string {
+  return file.replace(/^\//, '');
+}
+
+function isDirectory(a: string, file: string): boolean {
+  return Boolean('files' in asar.statFile(a, file));
+}
+
+function checkUnique(archive: string, file: string, allowList?: string): void {
+  if (allowList === undefined || !minimatch(file, allowList, { matchBase: true })) {
+    throw new Error(
+      `Detected unique file "${file}" in "${archive}" not covered by ` +
+        `allowList rule: "${allowList}"`,
+    );
+  }
+}
+
+export const fuseASARs = async ({
+  x64,
+  arm64,
+  output,
+  lipo = 'lipo',
+  uniqueAllowList,
+}: FuseASARsOptions): Promise<void> => {
+  d(`fusing ${x64} and ${arm64}`);
+
+  const x64Files = new Set(asar.listPackage(x64).map(toRelativePath));
+  const arm64Files = new Set(asar.listPackage(arm64).map(toRelativePath));
+
+  //
+  // Build set of unpacked directories and files
+  //
+
+  const unpackedFiles = new Set<string>();
+
+  function buildUnpacked(a: string, fileList: Set<string>): void {
+    for (const file of fileList) {
+      const stat = asar.statFile(a, file);
+
+      if (!('unpacked' in stat) || !stat.unpacked) {
+        continue;
+      }
+
+      if ('files' in stat) {
+        continue;
+      }
+      unpackedFiles.add(file);
+    }
+  }
+
+  buildUnpacked(x64, x64Files);
+  buildUnpacked(arm64, arm64Files);
+
+  //
+  // Build list of files/directories unique to each asar
+  //
+
+  for (const file of x64Files) {
+    if (!arm64Files.has(file)) {
+      checkUnique(x64, file, uniqueAllowList);
+    }
+  }
+  const arm64Unique = [];
+  for (const file of arm64Files) {
+    if (!x64Files.has(file)) {
+      checkUnique(arm64, file, uniqueAllowList);
+      arm64Unique.push(file);
+    }
+  }
+
+  //
+  // Find common bindings with different content
+  //
+
+  const commonBindings = [];
+  for (const file of x64Files) {
+    if (!arm64Files.has(file)) {
+      continue;
+    }
+
+    // Skip directories
+    if (isDirectory(x64, file)) {
+      continue;
+    }
+
+    const x64Content = asar.extractFile(x64, file);
+    const arm64Content = asar.extractFile(arm64, file);
+
+    if (x64Content.compare(arm64Content) === 0) {
+      continue;
+    }
+
+    if (!MACHO_MAGIC.has(x64Content.readUInt32LE(0))) {
+      throw new Error(`Can't reconcile two non-macho files ${file}`);
+    }
+
+    commonBindings.push(file);
+  }
+
+  //
+  // Extract both
+  //
+
+  const x64Dir = await fs.mkdtemp(path.join(os.tmpdir(), 'x64-'));
+  const arm64Dir = await fs.mkdtemp(path.join(os.tmpdir(), 'arm64-'));
+
+  try {
+    d(`extracting ${x64} to ${x64Dir}`);
+    asar.extractAll(x64, x64Dir);
+
+    d(`extracting ${arm64} to ${arm64Dir}`);
+    asar.extractAll(arm64, arm64Dir);
+
+    for (const file of arm64Unique) {
+      const source = path.resolve(arm64Dir, file);
+      const destination = path.resolve(x64Dir, file);
+
+      if (isDirectory(arm64, file)) {
+        d(`creating unique directory: ${file}`);
+        await fs.mkdirp(destination);
+        continue;
+      }
+
+      d(`xopying unique file: ${file}`);
+      await fs.mkdirp(path.dirname(destination));
+      await fs.copy(source, destination);
+    }
+
+    for (const binding of commonBindings) {
+      const source = await fs.realpath(path.resolve(arm64Dir, binding));
+      const destination = await fs.realpath(path.resolve(x64Dir, binding));
+
+      d(`fusing binding: ${binding}`);
+      execFileSync(lipo, [source, destination, '-create', '-output', destination]);
+    }
+
+    d(`creating archive at ${output}`);
+
+    const resolvedUnpack = Array.from(unpackedFiles).map((file) => path.join(x64Dir, file));
+
+    await asar.createPackageWithOptions(x64Dir, output, {
+      unpack: `{${resolvedUnpack.join(',')}}`,
+    });
+
+    d('done fusing');
+  } finally {
+    await Promise.all([fs.remove(x64Dir), fs.remove(arm64Dir)]);
+  }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,9 +36,9 @@ type MakeUniversalOpts = {
    */
   mergeASARs?: boolean;
   /**
-   * Minimatch pattern of paths that are allowed to be unique in ASARs.
+   * Minimatch pattern of paths that are allowed to be present in one of the ASAR files, but not in the other.
    */
-  mergeASARsAllowList?: string;
+  singleArchFiles?: string;
 };
 
 const dupedFiles = (files: AppFile[]) =>
@@ -201,7 +201,7 @@ export const makeUniversalApp = async (opts: MakeUniversalOpts): Promise<void> =
         x64AsarPath: path.resolve(tmpApp, 'Contents', 'Resources', 'app.asar'),
         arm64AsarPath: path.resolve(opts.arm64AppPath, 'Contents', 'Resources', 'app.asar'),
         outputAsarPath: output,
-        uniqueAllowList: opts.mergeASARsAllowList,
+        singleArchFiles: opts.singleArchFiles,
       });
 
       generatedIntegrity['Resources/app.asar'] = generateAsarIntegrity(output);

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,6 +294,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/minimatch@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
+  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
 "@types/minimist@^1.2.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"


### PR DESCRIPTION
In short, this adds a new option `fuseASARs` that, instead of checking that ASARs are exactly the same, will attempt to fuse them together into one and run `lipo` on shared bindings. 

uniqueAllowList` option handles files that are unique to each ASAR. Ultimately the goal is to put all of them together in the final ASAR, but I decided to go with an explicit allowlist so that the end user will always be aware of the extra files.

This helped us reduce universal `.dmg` size from `300mb` to `240mb` because we have quite a lot of data in our asar file at Signal.

## Example of debug output

```
  electron-universal fusing x64 and arm64 asars +16ms
  electron-universal Fusing /var/folders/9f/5h519zwn7kz7rbwr_wr7sptm0000gn/T/electron-universal-VDiwOl/Tmp.app/Contents/Resources/app.asar and /Users/indutny/Code/signalapp/Signal-Desktop-Private/release/mac-universal--arm64/Signal.app/Contents/Resources/app.asar +1ms
  electron-universal Extracting /var/folders/9f/5h519zwn7kz7rbwr_wr7sptm0000gn/T/electron-universal-VDiwOl/Tmp.app/Contents/Resources/app.asar to /var/folders/9f/5h519zwn7kz7rbwr_wr7sptm0000gn/T/x64-Vfv57T +985ms
  electron-universal Extracting /Users/indutny/Code/signalapp/Signal-Desktop-Private/release/mac-universal--arm64/Signal.app/Contents/Resources/app.asar to /var/folders/9f/5h519zwn7kz7rbwr_wr7sptm0000gn/T/arm64-imyBcQ +2s
  electron-universal Creating unique directory: node_modules/@signalapp/signal-client/prebuilds/darwin-arm64 +2s
  electron-universal Copying unique file: node_modules/@signalapp/signal-client/prebuilds/darwin-arm64/node.napi.node +1ms
  electron-universal Copying unique file: node_modules/ringrtc/build/darwin/libringrtc-arm64.node +6ms
  electron-universal Creating unique directory: node_modules/sharp/vendor/8.11.3/darwin-arm64v8 +12ms
  electron-universal Copying unique file: node_modules/sharp/vendor/8.11.3/darwin-arm64v8/platform.json +0ms
  electron-universal Copying unique file: node_modules/sharp/vendor/8.11.3/darwin-arm64v8/versions.json +2ms
  electron-universal Creating unique directory: node_modules/sharp/vendor/8.11.3/darwin-arm64v8/lib +0ms
  electron-universal Copying unique file: node_modules/sharp/vendor/8.11.3/darwin-arm64v8/lib/libvips-cpp.42.dylib +0ms
  electron-universal Copying unique file: node_modules/sharp/build/Release/sharp-darwin-arm64v8.node +22ms
  electron-universal Fusing binding: node_modules/better-sqlite3/build/Release/better_sqlite3.node +3ms
  electron-universal Creating archive at /var/folders/9f/5h519zwn7kz7rbwr_wr7sptm0000gn/T/electron-universal-VDiwOl/Tmp.app/Contents/Resources/app.asar +28ms
  electron-universal Done fusing +11s
  electron-universal copying snapshot file Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/v8_context_snapshot.arm64.bin to target application +2s
  electron-universal moving final universal app to target destination +4ms
```