### PR TITLE
feat: don't lipo binaries that are identical in the x64 and arm64 versions and match an allowlist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { spawn } from '@malept/cross-spawn-promise';
 import * as asar from 'asar';
 import * as crypto from 'crypto';
 import * as fs from 'fs-extra';
+import * as minimatch from 'minimatch';
 import * as os from 'os';
 import * as path from 'path';
 import * as plist from 'plist';
@@ -39,6 +40,10 @@ type MakeUniversalOpts = {
    * Minimatch pattern of paths that are allowed to be present in one of the ASAR files, but not in the other.
    */
   singleArchFiles?: string;
+  /**
+   * Minimatch pattern of binaries that are expected to be the same x64 binary in both of the ASAR files.
+   */
+  x64ArchFiles?: string;
 };
 
 const dupedFiles = (files: AppFile[]) =>
@@ -133,6 +138,16 @@ export const makeUniversalApp = async (opts: MakeUniversalOpts): Promise<void> =
       const x64Sha = await sha(path.resolve(opts.x64AppPath, machOFile.relativePath));
       const arm64Sha = await sha(path.resolve(opts.arm64AppPath, machOFile.relativePath));
       if (x64Sha === arm64Sha) {
+        if (
+          opts.x64ArchFiles === undefined ||
+          !minimatch(machOFile.relativePath, opts.x64ArchFiles, { matchBase: true })
+        ) {
+          throw new Error(
+            `Detected file "${machOFile.relativePath}" that's the same in both x64 and arm64 builds and not covered by the ` +
+              `x64ArchFiles rule: "${opts.x64ArchFiles}"`,
+          );
+        }
+
         d(
           'SHA for Mach-O file',
           machOFile.relativePath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,17 @@ export const makeUniversalApp = async (opts: MakeUniversalOpts): Promise<void> =
       const first = await fs.realpath(path.resolve(tmpApp, machOFile.relativePath));
       const second = await fs.realpath(path.resolve(opts.arm64AppPath, machOFile.relativePath));
 
+      const x64Sha = await sha(path.resolve(opts.x64AppPath, machOFile.relativePath));
+      const arm64Sha = await sha(path.resolve(opts.arm64AppPath, machOFile.relativePath));
+      if (x64Sha === arm64Sha) {
+        d(
+          'SHA for Mach-O file',
+          machOFile.relativePath,
+          `matches across builds ${x64Sha}===${arm64Sha}, skipping lipo`,
+        );
+        continue;
+      }
+
       d('joining two MachO files with lipo', {
         first,
         second,


### PR DESCRIPTION
This PR builds on #18 and adds an allowlist, currently called `x64ArchFiles` as requested by @MarshallOfSound.

I based the allowlist implementation on the existing 'checkSingleArch' allowlist.

@MarshallOfSound If this isn't up to snuff, let me know what you'd like and I'd be happy to improve it. (If it's more convenient for you to just take over the PR, that works for me, too.)