### PR TITLE
Exporting MakeUniversalOpts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { AsarMode, detectAsarMode, generateAsarIntegrity, mergeASARs } from './a
 import { sha } from './sha';
 import { d } from './debug';
 
-type MakeUniversalOpts = {
+export type MakeUniversalOpts = {
   /**
    * Absolute file system path to the x64 version of your application.  E.g. /Foo/bar/MyApp_x64.app
    */


### PR DESCRIPTION
This is to allow other packages to extract specific logic/options with typesafety

Context: Electron-Builder integrates with electron/universal and, right now, has to add a new config property whenever electron/universal changes/adds to `MakeUniversalOpts`. What I'd like to do is to be able to add a `universal: MakeUniversalOpts` object to our Mac Options such that it simply stays up to date whenever our electron/universal dep is updated

Ref: https://github.com/electron-userland/electron-builder/pull/6913#issuecomment-1146065657