### PR TITLE
fix: merged ASAR does not unpack when there is only one unpacked file

### DIFF
--- a/src/asar-utils.ts
+++ b/src/asar-utils.ts
@@ -195,8 +195,15 @@ export const mergeASARs = async ({
 
     const resolvedUnpack = Array.from(unpackedFiles).map((file) => path.join(x64Dir, file));
 
+    let unpack: string | undefined;
+    if (resolvedUnpack.length > 1) {
+      unpack = `{${resolvedUnpack.join(',')}}`;
+    } else if (resolvedUnpack.length === 1) {
+      unpack = resolvedUnpack[0];
+    }
+
     await asar.createPackageWithOptions(x64Dir, outputAsarPath, {
-      unpack: `{${resolvedUnpack.join(',')}}`,
+      unpack,
     });
 
     d('done merging');


### PR DESCRIPTION
Pattern `{file1,file2}` only works with multiple files. `minimatch` does not recognize pattern `{file1}` so if user only has one unpacked file, `asar` will not unpack it.

Resolve https://github.com/electron/universal/issues/54