### PR TITLE
fix: arm64/x64 inputs may contain universal binaries that are not the same

### DIFF
--- a/src/asar-utils.ts
+++ b/src/asar-utils.ts
@@ -157,7 +157,7 @@ export const mergeASARs = async ({
       continue;
     }
 
-    if (!MACHO_MAGIC.has(x64Content.readUInt32BE(0))) {
+    if (!MACHO_MAGIC.has(x64Content.readUInt32LE(0))) {
       throw new Error(`Can't reconcile two non-macho files ${file}`);
     }
 

--- a/src/asar-utils.ts
+++ b/src/asar-utils.ts
@@ -202,6 +202,7 @@ export const mergeASARs = async ({
     }
 
     d(`creating archive at ${outputAsarPath}`);
+
     const resolvedUnpack = Array.from(unpackedFiles).map((file) => path.join(x64Dir, file));
 
     let unpack: string | undefined;


### PR DESCRIPTION
One of my dependencies for some reason has universal binaries per platform, and they are not exactly the same bytewise. I'm unsure why. But I am certain they are functional.

In any case, this error is erroneously being thrown since it fails the previous byte comparison match.

```ts
      throw new Error(`Can't reconcile two non-macho files ${file}`);
```

CAFEBABE is the magic for universal binaries. This patch also checks to see if both binaries are CAFEBABE.  This will allow packaging to continue if both the arm and x64 packages have universal binaries.

https://github.com/apple-opensource-mirror/llvmCore/blob/0c60489d96c87140db9a6a14c6e82b15f5e5d252/include/llvm/Object/MachOFormat.h#L108-L112