### PR TITLE
fix: ignore differences caused by merged machO files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -183,11 +183,11 @@ export const makeUniversalApp = async (opts: MakeUniversalOpts): Promise<void> =
         path.resolve(opts.arm64AppPath, 'Contents', 'Resources', 'app'),
         { compareSize: true, compareContent: true },
       );
-      const differences = comparison.diffSet
+      const differences = comparison.diffSet!
         .filter(difference => difference.state !== "equal")
       d(`Found ${differences.length} difference(s) between the x64 and arm64 folders`);
       const nonMergedDifferences = differences
-        .filter(difference => !knownMergedMachOFiles.has(path.join('Contents', 'Resources', 'app', difference.relativePath, difference.name1)))
+        .filter(difference => !difference.name1 || !knownMergedMachOFiles.has(path.join('Contents', 'Resources', 'app', difference.relativePath, difference.name1)))
       d(`After discluding MachO files merged with lipo ${nonMergedDifferences.length} remain.`);
 
       if (nonMergedDifferences.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,10 +184,10 @@ export const makeUniversalApp = async (opts: MakeUniversalOpts): Promise<void> =
         { compareSize: true, compareContent: true },
       );
       const differences = comparison.diffSet
-		    .filter(difference => difference.state !== "equal")
+        .filter(difference => difference.state !== "equal")
       d(`Found ${differences.length} difference(s) between the x64 and arm64 folders`);
       const nonMergedDifferences = differences
-		    .filter(difference => !knownMergedMachOFiles.has(path.join('Contents', 'Resources', 'app', difference.relativePath, difference.name1)))
+        .filter(difference => !knownMergedMachOFiles.has(path.join('Contents', 'Resources', 'app', difference.relativePath, difference.name1)))
       d(`After discluding MachO files merged with lipo ${nonMergedDifferences.length} remain.`);
 
       if (nonMergedDifferences.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ export const makeUniversalApp = async (opts: MakeUniversalOpts): Promise<void> =
         );
       }
     }
-
+    const knownMergedMachOFiles = new Set();
     for (const machOFile of x64Files.filter((f) => f.type === AppFileType.MACHO)) {
       const first = await fs.realpath(path.resolve(tmpApp, machOFile.relativePath));
       const second = await fs.realpath(path.resolve(opts.arm64AppPath, machOFile.relativePath));
@@ -167,6 +167,7 @@ export const makeUniversalApp = async (opts: MakeUniversalOpts): Promise<void> =
         '-output',
         await fs.realpath(path.resolve(tmpApp, machOFile.relativePath)),
       ]);
+      knownMergedMachOFiles.add(machOFile.relativePath);
     }
 
     /**
@@ -182,8 +183,14 @@ export const makeUniversalApp = async (opts: MakeUniversalOpts): Promise<void> =
         path.resolve(opts.arm64AppPath, 'Contents', 'Resources', 'app'),
         { compareSize: true, compareContent: true },
       );
+      const differences = comparison.diffSet
+		    .filter(difference => difference.state !== "equal")
+      d(`Found ${differences.length} difference(s) between the x64 and arm64 folders`);
+      const nonMergedDifferences = differences
+		    .filter(difference => !knownMergedMachOFiles.has(path.join('Contents', 'Resources', 'app', difference.relativePath, difference.name1)))
+      d(`After discluding MachO files merged with lipo ${nonMergedDifferences.length} remain.`);
 
-      if (!comparison.same) {
+      if (nonMergedDifferences.length > 0) {
         d('x64 and arm64 app folders are different, creating dynamic entry ASAR');
         await fs.move(
           path.resolve(tmpApp, 'Contents', 'Resources', 'app'),


### PR DESCRIPTION
## Problem Description:
Once the strategy to merge the files succeeds we know the MachO files we've generated can run on both arm64 and x64. One interesting quirk here is @electron/universal only modifies the temp folder MachO files. It doesn't touch the arm64 folder.
That becomes a problem when the arm64 folder is compared with the temporary folder.
`@electron/universal` has modified the MachO files in the temp folder. So they should certainly be different from the ones in the arm64 folder.

## Solution Description:
This PR ads a set of files that `@electron/universal` merged, and then checks the results of the compare to specifically check that files **other** than the merged MachO files are different.
