### PR TITLE
fix: Run app.setAppPath() with the right path

### DIFF
--- a/entry-asar/has-asar.js
+++ b/entry-asar/has-asar.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('path');
 
 if (process.arch === 'arm64') {
   setPaths('arm64');
@@ -9,15 +9,15 @@ if (process.arch === 'arm64') {
 function setPaths(platform) {
   // This should return the full path, ending in something like
   // Notion.app/Contents/Resources/app.asar
-  const appPath = app.getAppPath()
-  const asarFile = `app-${platform}.asar`
+  const appPath = app.getAppPath();
+  const asarFile = `app-${platform}.asar`;
 
   // Maybe we'll handle this in Electron one day
   if (path.basename(appPath) === 'app.asar') {
-    const platformAppPath = path.join(path.dirname(appPath), asarFile)
+    const platformAppPath = path.join(path.dirname(appPath), asarFile);
 
     // This is an undocumented API. It exists.
-    app.setAppPath(platformAppPath)
+    app.setAppPath(platformAppPath);
   }
 
   process._archPath = require.resolve(`../${asarFile}`);

--- a/entry-asar/has-asar.js
+++ b/entry-asar/has-asar.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 if (process.arch === 'arm64') {
   setPaths('arm64');
 } else {
@@ -11,8 +13,8 @@ function setPaths(platform) {
   const asarFile = `app-${platform}.asar`
 
   // Maybe we'll handle this in Electron one day
-  if (appPath.includes('app.asar')) {
-    const platformAppPath = appPath.replace(/\.app\.asar$/, asarFile)
+  if (path.basename(appPath) === 'app.asar') {
+    const platformAppPath = path.join(path.dirname(appPath), asarFile)
 
     // This is an undocumented API. It exists.
     app.setAppPath(platformAppPath)

--- a/entry-asar/has-asar.js
+++ b/entry-asar/has-asar.js
@@ -1,7 +1,24 @@
 if (process.arch === 'arm64') {
-  process._archPath = require.resolve('../app-arm64.asar');
+  setPaths('arm64');
 } else {
-  process._archPath = require.resolve('../app-x64.asar');
+  setPaths('x64');
+}
+
+function setPaths(platform) {
+  // This should return the full path, ending in something like
+  // Notion.app/Contents/Resources/app.asar
+  const appPath = app.getAppPath()
+  const asarFile = `app-${platform}.asar`
+
+  // Maybe we'll handle this in Electron one day
+  if (appPath.includes('app.asar')) {
+    const platformAppPath = appPath.replace(/\.app\.asar$/, asarFile)
+
+    // This is an undocumented API. It exists.
+    app.setAppPath(platformAppPath)
+  }
+
+  process._archPath = require.resolve(`../${asarFile}`);
 }
 
 require(process._archPath);

--- a/entry-asar/no-asar.js
+++ b/entry-asar/no-asar.js
@@ -1,7 +1,24 @@
 if (process.arch === 'arm64') {
-  process._archPath = require.resolve('../app-arm64');
+  setPaths('arm64');
 } else {
-  process._archPath = require.resolve('../app-x64');
+  setPaths('x64');
+}
+
+function setPaths(platform) {
+  // This should return the full path, ending in something like
+  // Notion.app/Contents/Resources/app
+  const appPath = app.getAppPath()
+  const appFolder = `app-${platform}`
+
+  // Maybe we'll handle this in Electron one day
+  if (appPath.endsWith('app')) {
+    const platformAppPath = appPath.replace(/app$/, appFolder)
+
+    // This is an undocumented API. It exists.
+    app.setAppPath(platformAppPath)
+  }
+
+  process._archPath = require.resolve(`../${appFolder}`);
 }
 
 require(process._archPath);

--- a/entry-asar/no-asar.js
+++ b/entry-asar/no-asar.js
@@ -7,15 +7,15 @@ if (process.arch === 'arm64') {
 function setPaths(platform) {
   // This should return the full path, ending in something like
   // Notion.app/Contents/Resources/app
-  const appPath = app.getAppPath()
-  const appFolder = `app-${platform}`
+  const appPath = app.getAppPath();
+  const appFolder = `app-${platform}`;
 
   // Maybe we'll handle this in Electron one day
   if (path.basename(appPath) === 'app') {
-    const platformAppPath = path.join(path.dirname(appPath), appFolder)
+    const platformAppPath = path.join(path.dirname(appPath), appFolder);
 
     // This is an undocumented private API. It exists.
-    app.setAppPath(platformAppPath)
+    app.setAppPath(platformAppPath);
   }
 
   process._archPath = require.resolve(`../${appFolder}`);

--- a/entry-asar/no-asar.js
+++ b/entry-asar/no-asar.js
@@ -11,10 +11,10 @@ function setPaths(platform) {
   const appFolder = `app-${platform}`
 
   // Maybe we'll handle this in Electron one day
-  if (appPath.endsWith('app')) {
-    const platformAppPath = appPath.replace(/app$/, appFolder)
+  if (path.basename(appPath) === 'app') {
+    const platformAppPath = path.join(path.dirname(appPath), appFolder)
 
-    // This is an undocumented API. It exists.
+    // This is an undocumented private API. It exists.
     app.setAppPath(platformAppPath)
   }
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "author": "Samuel Attard",
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
-    "lint": "prettier --check \"src/**/*.ts\"",
-    "prettier:write": "prettier --write \"src/**/*.ts\"",
+    "lint": "prettier --check \"{src,entry-asar}/**/*.{js,ts}\"",
+    "prettier:write": "prettier --write \"{src,entry-asar}/**/*.{js,ts}\"",
     "prepublishOnly": "npm run build",
     "test": "exit 0",
     "prepare": "husky install"


### PR DESCRIPTION
Electron will set the `appPath` by looking for `package.json`. When using this module, this will end up being inside `app.asar`.

The problem is that from point on forward, APIs like `webContents.loadFile()` will be using this `app.asar` as the application's root. `webContents.loadFile('renderer/index.html')` will no longer work, since that file won't be inside `app.asar` - it'll actually be inside `app-x64.asar` or `app-arm64.asar`.

Users _can_ handle this problem in user land, but I assume that you need to know Electron pretty darn well. I propose that we fix this directly in the default asar. The same issue also exists with `app` folders, which this PR fixes, too.