### PR TITLE
fix: use Typescript for files in `entry-asar`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 dist
+entry-asar/*.js*
+entry-asar/*.ts
 *.app

--- a/entry-asar/ambient.d.ts
+++ b/entry-asar/ambient.d.ts
@@ -1,0 +1,19 @@
+declare namespace NodeJS {
+  interface Process extends EventEmitter {
+    // This is an undocumented private API. It exists.
+    _archPath: string;
+  }
+}
+
+declare module 'electron' {
+  const app: Electron.App;
+
+  namespace Electron {
+    interface App {
+      getAppPath: () => string;
+      setAppPath: (p: string) => void;
+    }
+  }
+
+  export { app };
+}

--- a/entry-asar/has-asar.ts
+++ b/entry-asar/has-asar.ts
@@ -1,5 +1,5 @@
-const { app } = require('electron');
-const path = require('path');
+import { app } from 'electron';
+import path from 'path';
 
 if (process.arch === 'arm64') {
   setPaths('arm64');
@@ -7,7 +7,7 @@ if (process.arch === 'arm64') {
   setPaths('x64');
 }
 
-function setPaths(platform) {
+function setPaths(platform: string) {
   // This should return the full path, ending in something like
   // Notion.app/Contents/Resources/app.asar
   const appPath = app.getAppPath();

--- a/entry-asar/no-asar.ts
+++ b/entry-asar/no-asar.ts
@@ -1,10 +1,13 @@
+import { app } from 'electron';
+import path from 'path';
+
 if (process.arch === 'arm64') {
   setPaths('arm64');
 } else {
   setPaths('x64');
 }
 
-function setPaths(platform) {
+function setPaths(platform: string) {
   // This should return the full path, ending in something like
   // Notion.app/Contents/Resources/app
   const appPath = app.getAppPath();

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
   "files": [
     "dist/*",
     "entry-asar/*",
+    "!entry-asar/**/*.ts",
     "README.md"
   ],
   "author": "Samuel Attard",
   "scripts": {
-    "build": "tsc && tsc -p tsconfig.esm.json",
-    "lint": "prettier --check \"{src,entry-asar}/**/*.{js,ts}\"",
-    "prettier:write": "prettier --write \"{src,entry-asar}/**/*.{js,ts}\"",
+    "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json && tsc -p tsconfig.entry-asar.json",
+    "lint": "prettier --check \"{src,entry-asar}/**/*.ts\"",
+    "prettier:write": "prettier --write \"{src,entry-asar}/**/*.ts\"",
     "prepublishOnly": "npm run build",
     "test": "exit 0",
     "prepare": "husky install"

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"]
+}

--- a/tsconfig.entry-asar.json
+++ b/tsconfig.entry-asar.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "entry-asar",
+  },
+  "include": [
+    "entry-asar"
+  ],
+  "exclude": []
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "module": "esnext",
     "outDir": "dist/esm"
-  }
+  },
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "declaration": true
   },
   "include": [
-    "src"
+    "src",
+    "entry-asar"
   ]
 }


### PR DESCRIPTION
Let's use TS for the files in `entry-asar` so we don't run into issues like #80 anymore. This also adds the missing `import`s to `entry-asar/no-asar.ts`.