### PR TITLE
build: fix repository.url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/electron/universal.git"
+    "url": "git+https://github.com/electron/universal.git"
   },
   "engines": {
     "node": ">=16.4"


### PR DESCRIPTION
Clears this warning during publish:

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/electron/universal.git"
```
