### PR TITLE
chore(deps): bump `@electron/asar` to `3.3.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@electron/asar": "^3.2.7",
+    "@electron/asar": "^3.3.1",
     "@malept/cross-spawn-promise": "^2.0.0",
     "debug": "^4.3.1",
     "dir-compare": "^4.2.0",

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -306,6 +306,7 @@ exports[`makeUniversalApp asar mode should shim asars with different unpacked di
               "files": {
                 "file.txt": {
                   "link": "private/var/file.txt",
+                  "unpacked": true,
                 },
               },
             },
@@ -327,6 +328,7 @@ exports[`makeUniversalApp asar mode should shim asars with different unpacked di
     },
     "var": {
       "link": "private/var",
+      "unpacked": true,
     },
   },
 }
@@ -433,7 +435,7 @@ exports[`makeUniversalApp asar mode should shim asars with different unpacked di
   "Contents/Info.plist": {
     "Resources/app-arm64.asar": {
       "algorithm": "SHA256",
-      "hash": "c7563e17e768e508045ffb888935d50dbf785bbba3ffb0068e5472fda4f6c199",
+      "hash": "d06a628e759f54def7ff8785a077b3a3d756882cb84ee99e9725966226e1f195",
     },
     "Resources/app-x64.asar": {
       "algorithm": "SHA256",

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,10 +297,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@electron/asar@^3.2.7":
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.2.7.tgz#bb8117dc6fd0c06a922ae7fb1c0e2d433e35a6e5"
-  integrity sha512-8FaSCAIiZGYFWyjeevPQt+0e9xCK9YmJ2Rjg5SXgdsXon6cRnU0Yxnbe6CvJbQn26baifur2Y2G5EBayRIsjyg==
+"@electron/asar@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.3.1.tgz#cd14e897770d9844673dd7c1dc8944e086e1e0ea"
+  integrity sha512-WtpC/+34p0skWZiarRjLAyqaAX78DofhDxnREy/V5XHfu1XEXbFCSSMcDQ6hNCPJFaPy8/NnUgYuf9uiCkvKPg==
   dependencies:
     commander "^5.0.0"
     glob "^7.1.6"


### PR DESCRIPTION
We're still using a pre-TypeScript-rewrite version of `@electron/asar`. cc @mmaietta 