### PR TITLE
test: add explicit imports for `jest` functions

### DIFF
--- a/test/asar-utils.spec.ts
+++ b/test/asar-utils.spec.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 
 import { AsarMode, detectAsarMode, generateAsarIntegrity } from '../src/asar-utils';
+import { describe, expect, it } from '@jest/globals';
 
 const asarsPath = path.resolve(__dirname, 'fixtures', 'asars');
 const appsPath = path.resolve(__dirname, 'fixtures', 'apps');

--- a/test/file-utils.spec.ts
+++ b/test/file-utils.spec.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 
 import { AppFile, AppFileType, getAllAppFiles } from '../src/file-utils';
+import { beforeAll, describe, expect, it } from '@jest/globals';
 
 const appsPath = path.resolve(__dirname, 'fixtures', 'apps');
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { makeUniversalApp } from '../dist/cjs/index';
 import { createTestApp, templateApp, VERIFY_APP_TIMEOUT, verifyApp } from './util';
 import { createPackage, createPackageWithOptions } from '@electron/asar';
+import { afterEach, describe, expect, it } from '@jest/globals';
 
 const appsPath = path.resolve(__dirname, 'fixtures', 'apps');
 const appsOutPath = path.resolve(__dirname, 'fixtures', 'apps', 'out');

--- a/test/sha.spec.ts
+++ b/test/sha.spec.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 
 import { sha } from '../src/sha';
+import { describe, expect, it } from '@jest/globals';
 
 describe('sha', () => {
   it('should correctly hash a file', async () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import plist from 'plist';
 import * as fileUtils from '../dist/cjs/file-utils';
 import { getRawHeader } from '@electron/asar';
+import { expect } from '@jest/globals';
 
 // We do a LOT of verifications in `verifyApp` 😅
 // exec universal binary -> verify ALL asars -> verify ALL app dirs -> verify ALL asar integrity entries

--- a/test/util.ts
+++ b/test/util.ts
@@ -6,7 +6,8 @@ import * as path from 'path';
 import plist from 'plist';
 import * as fileUtils from '../dist/cjs/file-utils';
 import { getRawHeader } from '@electron/asar';
-import { expect } from '@jest/globals';
+
+declare const expect: typeof import('@jest/globals').expect;
 
 // We do a LOT of verifications in `verifyApp` 😅
 // exec universal binary -> verify ALL asars -> verify ALL app dirs -> verify ALL asar integrity entries


### PR DESCRIPTION
`describe`, `expect` and other global Jest types are marked as unresolved on my IDE because we're missing `"types": ["jest"]`.