### PR TITLE
fix: make sure unpacked asar resources are still identified as APP_CODE

### DIFF
--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -45,7 +45,9 @@ export const getAllAppFiles = async (appPath: string): Promise<AppFile[]> => {
           throw e;
         }
       }
-      if (p.endsWith('.asar')) {
+      // Need to match both e.g. `Contents/Resources/app.asar` and
+      // `Contents/Resources/app.asar.unpacked/node_modules/fsevents/fsevents.node`
+      if (p.endsWith('.asar') || p.includes('.asar.unpacked/')) {
         fileType = AppFileType.APP_CODE;
       } else if (fileOutput.startsWith(MACHO_PREFIX)) {
         fileType = AppFileType.MACHO;


### PR DESCRIPTION
PR #124 introduced a regression where the following path:

    Contents/Resources/app.asar.unpacked/node_modules/fsevents/fsevents.node

Would get identified as `AppFileType.MACHO` instead of `AppFileType.APP_CODE` as it was previously

We need to make sure that path containing `.asar.unpacked/` are also treated as `APP_CODE`

Otherwise, universal native Node modules like `fsevents.node` get passed to [this check](https://github.com/electron/universal/blob/5b957e6858afca80a53a81ca66e2cd274f6357a9/src/index.ts#L161-L176) that results in the following error:

```
Error: Detected file "Contents/Resources/app.asar.unpacked/node_modules/fsevents/fsevents.node" that's the same in both x64 and arm64 builds and not covered by the x64ArchFiles rule
```