### PR TITLE
fix: don't star import from plist package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import * as asar from '@electron/asar';
 import { spawn } from '@malept/cross-spawn-promise';
 import * as dircompare from 'dir-compare';
 import { minimatch } from 'minimatch';
-import * as plist from 'plist';
+import plist from 'plist';
 
 import { AsarMode, detectAsarMode, isUniversalMachO, mergeASARs } from './asar-utils.js';
 import { AppFile, AppFileType, fsMove, getAllAppFiles, readMachOHeader } from './file-utils.js';


### PR DESCRIPTION
We either don't have enough test coverage here, or Vitest is silently making this work during testing, but ran into this when doing the Node.js 22 bump for `@electron/fuses`.